### PR TITLE
Allow it to work with chunked sitemap

### DIFF
--- a/src/PathProcessor.php
+++ b/src/PathProcessor.php
@@ -19,7 +19,7 @@ class PathProcessor implements InboundPathProcessorInterface {
       list($check_path) = explode('?', $check_path);
     }
 
-    if ($check_path == '/sitemap.xml') {
+    if (strpos($check_path, '/sitemap.xml') !== FALSE) {
       \Drupal::request()->attributes->set('_disable_route_normalizer', TRUE);
     }
 


### PR DESCRIPTION
When there are more links than the max limit set, the sitemap gets split up into sub-maps with paths like `/sitemaps/{chunk_id}/sitemap.xml`